### PR TITLE
correção packages.json para o heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "nodemon ./bin/www",
+    "start": "node ./bin/www",
+    "develop": "nodemon  ./bin/www",
     "build-css": "cd ./public/css &&  ../../node_modules/.bin/stylus --compress < main.styl > main.css"
   },
   "dependencies": {


### PR DESCRIPTION
Atualização scripts do pacote, para evitar problemas com instância heroku.

Por padrão uso `nodemon` para rodar servidor web, porém eu marquei o pacote como dependência dev e o Heroku não instala pacotes do `devDependencies` do `packages.json`.

Criei um novo comando `npm` para desenvolvimento local e voltei o comando antigo para funcionar corretamente com o Heroku.

